### PR TITLE
Fix bugs

### DIFF
--- a/backend/backend/settings/__init__.py
+++ b/backend/backend/settings/__init__.py
@@ -84,3 +84,5 @@ GOOGLE_APP_ID = prod_required_env("DJANGO_GOOGLE_APP_ID", default=None)
 FACEBOOK_CLIENT_ID = prod_required_env("DJANGO_FACEBOOK_CLIENT_ID", default=None)
 
 FACEBOOK_CLIENT_SECRET = prod_required_env("DJANGO_FACEBOOK_CLIENT_SECRET", default=None)
+
+SESSION_COOKIE_SAMESITE = None

--- a/frontend/components/ChangePassword.js
+++ b/frontend/components/ChangePassword.js
@@ -6,7 +6,7 @@ import Spacer from '@wui/layout/spacer';
 import Textbox from '@wui/input/textbox';
 import Typography from '@wui/basics/typography';
 
-import useInputFieldState from '@@/utils/hooks';
+import { useInputFieldState } from '@@/utils/hooks';
 import { changePassword, refresh } from '@@/utils/API';
 import { INVALID_PASSWORD } from '@@/utils/constants';
 import Success from '@@/components/Success';


### PR DESCRIPTION
Changing the SESSION_COOKIE_SAMESITE setting because it's necessary for now when deployed. It may be preferable to store the refresh token in a separate cookie so that we can change this back.