### PR TITLE
Allow redirects to willing subdomains

### DIFF
--- a/backend/authentication/tests/views/test_views.py
+++ b/backend/authentication/tests/views/test_views.py
@@ -1,6 +1,7 @@
 from unittest.mock import patch, Mock
 
 import pytest
+from django.test import override_settings
 from django.urls import reverse
 
 from authentication.factories import UserFactory
@@ -82,6 +83,15 @@ class TestRegister:
 
     def test_redirect(self, authenticate_and_test):
         redirect_url = "http://localhost:1234/test_path"
+        data = {
+            **USER_DATA,
+            "next": redirect_url,
+        }
+        authenticate_and_test("authentication:register", data, redirect_url=redirect_url)
+
+    @override_settings(VALID_REDIRECT_HOSTNAMES=["*.testing.com"])
+    def test_redirect_wildcard(self, authenticate_and_test):
+        redirect_url = "http://sub.testing.com"
         data = {
             **USER_DATA,
             "next": redirect_url,

--- a/backend/authentication/tests/views/utils.py
+++ b/backend/authentication/tests/views/utils.py
@@ -7,7 +7,7 @@ from authentication.utils import REFRESH_TOKEN_SESSION_KEY
 
 def assert_successful_response(response, redirect_url):
     assert response.status_code == 200
-    assert response.json()["next"] == redirect_url or settings.DEFAULT_REDIRECT_URL
+    assert response.json()["next"] == (redirect_url or settings.DEFAULT_REDIRECT_URL)
 
 
 def assert_authenticated(client):

--- a/backend/authentication/utils.py
+++ b/backend/authentication/utils.py
@@ -1,4 +1,5 @@
 import json
+from fnmatch import fnmatchcase
 from urllib.parse import urlparse
 
 from django.conf import settings
@@ -48,7 +49,10 @@ def get_valid_redirect_url(url):
     is_valid = URLValidator()
     try:
         is_valid(url)
-        if urlparse(url).hostname not in settings.VALID_REDIRECT_HOSTNAMES:
+        host_name = urlparse(url).hostname
+        if not any(
+            fnmatchcase(host_name, pattern) for pattern in settings.VALID_REDIRECT_HOSTNAMES
+        ):
             raise ValidationError("Invalid host")
         return url
     except ValidationError:

--- a/backend/backend/settings/__init__.py
+++ b/backend/backend/settings/__init__.py
@@ -68,7 +68,10 @@ AUTH_PASSWORD_VALIDATORS = [
 DEFAULT_REDIRECT_URL = prod_required_env(
     "DJANGO_DEFAULT_REDIRECT_URL", "http://localhost:3000"
 )
-VALID_REDIRECT_HOSTNAMES = ["localhost"]
+VALID_REDIRECT_HOSTNAMES = ["*.willing.com"]
+
+if not PRODUCTION:
+    VALID_REDIRECT_HOSTNAMES.append("localhost")
 
 GOOGLE_APP_ID = prod_required_env("DJANGO_GOOGLE_APP_ID", default=None)
 


### PR DESCRIPTION
Noticed that this wasn't in yet when checking out dev.members.willing.com.

We probably want this to be configurable - We could use environment variables, but maybe the Django admin is a better place for that.