### PR TITLE
ZAPPA: Add custom IAM role name

### DIFF
--- a/backend/zappa_settings.json
+++ b/backend/zappa_settings.json
@@ -9,11 +9,17 @@
       "SubnetIds": ["subnet-02c8170b670b0c4df", "subnet-0a9bd034e0d43d078"],
       "SecurityGroupIds": ["sg-074c6991e4690e44a"]
     },
-    "certificate_arn": "arn:aws:acm:us-east-1:818831340115:certificate/0b42f140-7af8-4369-91f9-debd04bc1e2d"
+    "certificate_arn": "arn:aws:acm:us-east-1:818831340115:certificate/0b42f140-7af8-4369-91f9-debd04bc1e2d",
+    "manage_roles": false,
+    "role_name": "PortunusZappaRole"
   },
   "dev": {
     "extends": "base",
     "domain": "api-dev.portunus.willing.com"
+  },
+  "qa": {
+    "extends": "base",
+    "domain": "api-qa.portunus.willing.com"
   },
   "staging": {
     "extends": "base",


### PR DESCRIPTION
This is needed so we can use the same role to kick of zappa deploys from codebuild. Does this need to go into zygoat?
Also added `qa`