### PR TITLE
BACKEND: define CORS whitelist when DEBUG is false

### DIFF
--- a/backend/backend/settings/__init__.py
+++ b/backend/backend/settings/__init__.py
@@ -52,6 +52,11 @@ SIMPLE_JWT = {
 
 CORS_ORIGIN_ALLOW_ALL = DEBUG
 CORS_ALLOW_CREDENTIALS = True
+if not DEBUG:
+    CORS_ORIGIN_REGEX_WHITELIST = [
+        r"^https://[\w.]+\.willing\.com$",
+        r"^https://[\w.]+\.legalplans\.com$",
+    ]
 
 BASE_URL = env("DJANGO_BASE_URL", default="http://localhost:3000/")
 

--- a/backend/backend/tests/test_settings.py
+++ b/backend/backend/tests/test_settings.py
@@ -1,0 +1,27 @@
+import pytest
+from django.urls import reverse
+from django.test import override_settings
+from rest_framework.test import APIClient
+
+
+@pytest.fixture
+def client():
+    return APIClient()
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.parametrize(
+    "whitelisted_domain", ["https://app.willing.com", "https://members.legalplans.com",]
+)
+def test_cors_allows_whitelisted_domains(client, whitelisted_domain):
+    response = client.get(reverse("set_csrf_cookie"), HTTP_ORIGIN=whitelisted_domain)
+    assert response.has_header("access-control-allow-origin")
+
+
+@override_settings(DEBUG=False)
+@pytest.mark.parametrize(
+    "unknown_domain", ["http://app.willing.com", "https://notwilling.com",]
+)
+def test_cors_blocks_unknown_domains(client, unknown_domain):
+    response = client.get(reverse("set_csrf_cookie"), Origin=unknown_domain)
+    assert not response.has_header("access-control-allow-origin")


### PR DESCRIPTION
For now this will accept any subdomain of willing.com or legalplans.com.