### PR TITLE
AUTH: update logout view to preserve query params on redirect

### DIFF
--- a/backend/authentication/urls.py
+++ b/backend/authentication/urls.py
@@ -8,7 +8,6 @@ app_name = "authentication"
 urlpatterns = [
     path("register/", views.register, name="register"),
     path("login/", views.login, name="login"),
-    path("logout/", views.logout, name="logout"),
     path("users/settings/", views.get_current_user_settings, name="get_current_user"),
     path("users/", views.CreateUserView.as_view(), name="create_user"),
     path("users/<str:portunus_uuid>/", views.RetrieveUserView.as_view(), name="retrieve_user"),

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -1,6 +1,5 @@
 import json
 
-from django.contrib.auth import logout as logout_user
 from django.views.decorators.http import require_POST
 from django.core.exceptions import ValidationError
 from rest_framework.generics import CreateAPIView, RetrieveAPIView
@@ -21,7 +20,6 @@ from .utils import (
     check_and_change_password,
     check_onetime_token,
     make_response,
-    blacklist_user_tokens,
     get_valid_redirect_url,
 )
 from .errors import AUTH_FAILURE, INVALID_TOKEN, INVALID_EMAIL
@@ -48,17 +46,6 @@ def make_auth_view(serializer_class):
 
 register = make_auth_view(RegistrationSerializer)
 login = make_auth_view(LoginSerializer)
-
-
-@api_view(["POST"])
-@permission_classes([IsAuthenticated])
-def logout(request):
-    if request.user.is_anonymous:
-        return make_response()
-
-    blacklist_user_tokens(request.user)
-    logout_user(request)
-    return make_response()
 
 
 @api_view(["POST"])

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -1,3 +1,5 @@
+from urllib import parse
+
 from django.http import HttpResponse
 from django.views.decorators.http import require_GET
 from django.views.decorators.csrf import ensure_csrf_cookie
@@ -9,6 +11,7 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 
 from authentication.utils import blacklist_user_tokens
+from shared import frontend_urls
 
 
 @api_view(["GET"])
@@ -24,8 +27,13 @@ def set_csrf(request):
     return HttpResponse("success", status=HTTP_200_OK)
 
 
+@api_view(["GET"])
 def logout(request):
     if request.user.is_authenticated:
         blacklist_user_tokens(request.user)
     logout_user(request)
-    return redirect("/")
+
+    query_string = ""
+    if request.query_params:
+        query_string = f"?{parse.urlencode(request.query_params)}"
+    return redirect(f"{frontend_urls.LOGIN}{query_string}")

--- a/backend/shared/frontend_urls.py
+++ b/backend/shared/frontend_urls.py
@@ -1,0 +1,1 @@
+LOGIN = "/login"


### PR DESCRIPTION
Closes #87 (members should ideally specify a next parameter when redirecting to logout, but Portunus should now redirect back to members by default if it is omitted)