### PR TITLE
DEV: use different port for portunus in local development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,8 +11,6 @@ services:
     environment:
       - POSTGRES_PASSWORD=postgres
     image: postgres:11
-    ports:
-      - 5432:5432
   frontend:
     build:
       context: frontend
@@ -27,7 +25,7 @@ services:
       - backend
     image: caddy:2.0.0
     ports:
-      - 3000:3000
+      - 3001:3000
     volumes:
       - ./Caddyfile:/etc/caddy/Caddyfile
 version: '3.4'


### PR DESCRIPTION
This will make it easier to use both portunus and members locally (probably should have done it earlier). There is also no need to expose the db port in dev.