### PR TITLE
LOGGING: add logging for various auth events

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -13,6 +13,7 @@ from django.core.validators import validate_email
 from sentry_sdk import capture_exception, configure_scope
 
 from authentication.utils import blacklist_user_tokens
+from shared.utils.logging import log_event, log_view_outcome
 
 from .serializers import (
     RegistrationSerializer,
@@ -36,12 +37,13 @@ from shared.email import PortunusMailer
 from shared.permissions import IsSameUserOrAdmin
 
 
-def make_auth_view(*serializer_classes):
+def make_auth_view(*serializer_classes, action):
     """
     Creates a view from an ordered list of serializers. If any serializer is valid with the
     given data, log the user in and redirect them to the given URL.
     """
 
+    @log_view_outcome(event_type=action)
     @require_POST
     def view(request):
         data = json.loads(request.body)
@@ -65,10 +67,11 @@ def make_auth_view(*serializer_classes):
     return view
 
 
-register = make_auth_view(RegistrationSerializer, LoginSerializer)
-login = make_auth_view(LoginSerializer)
+register = make_auth_view(RegistrationSerializer, LoginSerializer, action="register")
+login = make_auth_view(LoginSerializer, action="login")
 
 
+@log_view_outcome()
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def change_password(request):
@@ -83,6 +86,7 @@ def change_password(request):
     return check_and_change_password(request, user, new_password)
 
 
+@log_view_outcome()
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def request_email_change(request):
@@ -106,6 +110,7 @@ def request_email_change(request):
     return make_response()
 
 
+@log_view_outcome()
 @api_view(["POST"])
 @permission_classes([IsAuthenticated])
 def update_email(request):
@@ -135,9 +140,16 @@ def request_password_reset(request):
         user = User.objects.get(email=email.lower())
     except User.DoesNotExist:
         # Send back success even if the account DNE to avoid leaking user emails.
+        extra_data = {
+            "success": False,
+            "email": email,
+            "error": "Matching user does not exist",
+        }
+        log_event("request_password_reset", request, extra_data=extra_data)
         return make_response()
 
     PortunusMailer.send_password_reset(user)
+    log_event("request_password_reset", request, extra_data={"success": True})
     return make_response()
 
 
@@ -157,6 +169,7 @@ def admin_request_password_reset(request):
     return make_response()
 
 
+@log_view_outcome()
 @api_view(["POST"])
 def reset_password(request):
     uid = request.data.get("portunus_uuid")

--- a/backend/backend/settings/zygoat_settings.py
+++ b/backend/backend/settings/zygoat_settings.py
@@ -232,3 +232,10 @@ SIMPLE_JWT = {
     "SIGNING_KEY": None,
     "VERIFYING_KEY": VERIFYING_KEY,
 }
+
+LOGGING = {
+    "version": 1,
+    "disable_existing_loggers": False,
+    "handlers": {"console": {"class": "logging.StreamHandler"}},
+    "root": {"handlers": ["console"], "level": "INFO"},
+}

--- a/backend/backend/views.py
+++ b/backend/backend/views.py
@@ -11,7 +11,9 @@ from rest_framework.response import Response
 from rest_framework.status import HTTP_200_OK
 
 from authentication.utils import blacklist_tokens_for_request, is_valid_redirect_url
+
 from shared import frontend_urls
+from shared.utils.logging import log_event
 
 
 @api_view(["GET"])
@@ -29,7 +31,8 @@ def set_csrf(request):
 
 @api_view(["GET"])
 def logout(request):
-    blacklist_tokens_for_request(request)
+    user = blacklist_tokens_for_request(request)
+    log_event("logout", request, extra_data={"user": user.email})
     logout_user(request)
     query_params = request.query_params
 

--- a/backend/shared/utils/logging.py
+++ b/backend/shared/utils/logging.py
@@ -1,0 +1,61 @@
+import logging
+import json
+from functools import wraps
+from time import gmtime, strftime
+
+logger = logging.getLogger(__name__)
+
+
+def _default_get_user_identifier(request):
+    if request.user.is_authenticated:
+        return request.user.email
+    return None
+
+
+def log_event(event_type, request, extra_data=None, level=logging.INFO):
+    """
+    Logs an event with default information and, optionally, additional data included
+
+    :param event_type: Event identifier to show in the logs.
+    :param request: Django request associated with the event.
+    :param extra_data: Extra data to include in the logged event.
+    :param level: Log level to use.
+    """
+    event_dict = {
+        "event_type": event_type,
+        "timestamp": strftime("%Y-%m-%d %H:%M:%S", gmtime()),
+        "ip_address": request.META["REMOTE_ADDR"],
+    }
+    user_identifier = _default_get_user_identifier(request)
+    if user_identifier:
+        event_dict["user"] = user_identifier
+
+    if extra_data:
+        event_dict.update(extra_data)
+
+    logger.log(level, f"ZYGOAT: {json.dumps(event_dict)}")
+
+
+def log_view_outcome(event_type=None):
+    """
+    Creates a decorator that logs basic info about the result of the view
+
+    :param event_type: Event identifier to show in the logs.
+    :return: A decorator that logs the outcome of a view.
+    """
+
+    def decorator(view):
+        @wraps(view)
+        def inner(request, *args, **kwargs):
+            response = view(request, *args, **kwargs)
+
+            extra_data = {
+                "status_code": response.status_code,
+            }
+            log_event(event_type or view.__name__, request, extra_data=extra_data)
+
+            return response
+
+        return inner
+
+    return decorator


### PR DESCRIPTION
The new logging module provides two helpers for adding logging: the `log_event` function, which can be called directly to log an event, and the `log_view_outcome` decorator, which can be added to a view to log basic information about the response.

Currently, this logs the status code, timestamp, ip address, and user email for the decorated views.

If this looks good I will add it to the willing-zg django app and we can use it in other zygoat repos, too.

I'm using the `log_event` function for password reset requests, because it currently does not send error responses when the email is not found to avoid leaking user data.