### PR TITLE
API: accommodate camel case renderer and parser for API calls

### DIFF
--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -5,6 +5,7 @@ from calendar import timegm
 from django.views.decorators.http import require_POST
 from django.core.exceptions import ValidationError
 from rest_framework.generics import CreateAPIView, RetrieveDestroyAPIView
+from rest_framework.renderers import JSONRenderer
 from rest_framework_simplejwt.tokens import RefreshToken
 from rest_framework_simplejwt.views import TokenRefreshView as SimpleJWTTokenRefreshView
 from rest_framework.permissions import IsAuthenticated, IsAdminUser
@@ -116,7 +117,7 @@ def request_email_change(request):
 def update_email(request):
     user = request.user
     token = request.data.get("token")
-    new_email = request.data.get("newEmail")
+    new_email = request.data.get("new_email")
 
     if not check_change_email_token(token, user):
         return make_response(False, {"error": INVALID_TOKEN})
@@ -217,6 +218,7 @@ class TokenRefreshView(SimpleJWTTokenRefreshView):
 class CreateUserView(CreateAPIView):
     permission_classes = [IsAdminUser]
     serializer_class = CreateUserSerializer
+    renderer_classes = [JSONRenderer]
 
     def create(self, request, *args, **kwargs):
         serializer = self.serializer_class(data=request.data)

--- a/frontend/components/AuthBase.js
+++ b/frontend/components/AuthBase.js
@@ -71,7 +71,7 @@ const AuthBase = ({
     if (error.response && error.response.data) {
       setInputErrors(error.response.data);
     } else {
-      setInputErrors({ non_field_errors: 'An unknown error has occurred. Please try again.' });
+      setInputErrors({ nonFieldErrors: 'An unknown error has occurred. Please try again.' });
     }
     setProcessing(false);
   };
@@ -98,7 +98,7 @@ const AuthBase = ({
   return (
     <>
       <Typography variant="h4">{headerText}</Typography>
-      <Form error={inputErrors.non_field_errors} onSubmit={handleSubmit} noMargin>
+      <Form error={inputErrors.nonFieldErrors} onSubmit={handleSubmit} noMargin>
         <Textbox
           name="email"
           type="email"

--- a/frontend/components/ChangeEmail.js
+++ b/frontend/components/ChangeEmail.js
@@ -66,7 +66,7 @@ const ChangeEmail = () => {
       }
       setInputErrors({ submitError });
     } else {
-      setInputErrors({ non_field_errors: 'An unknown error has occurred. Please try again.' });
+      setInputErrors({ submitError: 'An unknown error has occurred. Please try again.' });
     }
     setSuccess(false);
   };
@@ -80,7 +80,7 @@ const ChangeEmail = () => {
     refresh().then(() => {
       changeUserEmail({
         password,
-        new_email: newEmail.toLowerCase(),
+        newEmail: newEmail.toLowerCase(),
       })
         .then(() => setSuccess(true))
         .catch(handleError);

--- a/frontend/components/ChangePassword.js
+++ b/frontend/components/ChangePassword.js
@@ -68,7 +68,7 @@ const ChangePassword = () => {
           : 'Your current password did not match the one we have on file. Try again.';
       setInputErrors({ submitError });
     } else {
-      setInputErrors({ non_field_errors: 'An unknown error has occurred. Please try again.' });
+      setInputErrors({ submitError: 'An unknown error has occurred. Please try again.' });
     }
     setSuccess(false);
   };
@@ -82,7 +82,7 @@ const ChangePassword = () => {
     refresh().then(() => {
       changePassword({
         password,
-        new_password: newPassword,
+        newPassword,
       })
         .then(response => {
           setSuccess(true);

--- a/frontend/components/CompleteChangeEmail.js
+++ b/frontend/components/CompleteChangeEmail.js
@@ -84,7 +84,7 @@ const ChangeEmailComplete = ({ token, newEmail }) => {
 
 ChangeEmailComplete.propTypes = {
   token: PropTypes.string.isRequired,
-  new_email: PropTypes.string.isRequired,
+  newEmail: PropTypes.string.isRequired,
 };
 
 export default observer(ChangeEmailComplete);

--- a/frontend/components/CompleteResetPassword/index.js
+++ b/frontend/components/CompleteResetPassword/index.js
@@ -43,8 +43,8 @@ const ResetPasswordComplete = ({ uuid, token, action, resendEmail }) => {
       return;
     }
     completePasswordReset({
-      new_password: newPassword1,
-      portunus_uuid: uuid,
+      newPassword: newPassword1,
+      portunusUuid: uuid,
       token,
     })
       .then(response => {

--- a/frontend/pages/set-password/[uuid]/[token].js
+++ b/frontend/pages/set-password/[uuid]/[token].js
@@ -16,7 +16,7 @@ const SetPassword = () => {
         uuid={uuid}
         token={token}
         action="set"
-        resendEmail={() => sendNewUserEmail({ portunus_uuid: uuid })}
+        resendEmail={() => sendNewUserEmail({ portunusUuid: uuid })}
       />
     </Layout>
   );


### PR DESCRIPTION
Portunus was apparently not using the camel case parsers and renderers before #195 - the drf settings were being overridden in `settings/__init__.py`. This updates the API usages to use camel case for request parameters and response parsing. Most of these requests would actually be fine unchanged because they would not be affected by the parser, but I figure we should use it as intended.

I'm updating the create/delete user view to keep using the old parser/renderer for now because members currently expects snake case in the response.

There are a couple bugs that this fixes, too - the unknown error response on the change email/change password pages was not working because the state key being set was not used. Also, the complete email change page had a mismatch in the name of the prop being passed/received.