### PR TITLE
FRONTEND: look for snake cased non_field_errors in login/register api…

### DIFF
--- a/frontend/components/AuthBase.js
+++ b/frontend/components/AuthBase.js
@@ -80,7 +80,7 @@ const AuthBase = ({
     if (error.response && error.response.data) {
       setInputErrors(error.response.data);
     } else {
-      setInputErrors({ nonFieldErrors: 'An unknown error has occurred. Please try again.' });
+      setInputErrors({ non_field_errors: 'An unknown error has occurred. Please try again.' });
     }
     setProcessing(false);
   };
@@ -105,7 +105,7 @@ const AuthBase = ({
   return (
     <>
       <Typography variant="h4">{headerText}</Typography>
-      <Form error={inputErrors.nonFieldErrors} onSubmit={handleSubmit} noMargin>
+      <Form error={inputErrors.non_field_errors} onSubmit={handleSubmit} noMargin>
         <Textbox
           name="email"
           type="email"


### PR DESCRIPTION
… responses

The login and register views are implemented as vanilla django views
to ensure that CSRF protection is applied as recommended in the DRF
docs. This means that the camel case to snake case custom renderers
are not used to build the response and we need to check for
`non_field_errors` and not `nonFieldErrors`.

Closes #226 