### PR TITLE
BACKEND: bump simplejwt and cryptography versions

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -4,8 +4,8 @@ django-cors-headers==3.5.0
 djangorestframework==3.12.2
 django-environ==0.4.5
 djangorestframework-camel-case==1.2.0
-djangorestframework-simplejwt==4.4.0
-cryptography==3.2.1
+djangorestframework-simplejwt==4.6.0
+cryptography==3.3.1
 simplejwt-extensions==0.2.1
 zappa==0.51.0
 requests==2.23.0


### PR DESCRIPTION
This should fix the build - the simplejwt version needs to be bumped to handle pyjwt 2.0. Pre-commit hooks indicated that cryptography should be bumped as well.