### PR TITLE
BACKEND: do not lock out registration attempts for accounts that do n…

### DIFF
--- a/backend/authentication/serializers.py
+++ b/backend/authentication/serializers.py
@@ -26,6 +26,8 @@ class RegistrationSerializer(serializers.ModelSerializer):
 
 
 class LoginSerializer(serializers.ModelSerializer):
+    bad_credentials_error = _("Invalid username or password")
+
     class Meta:
         model = User
         fields = ("email", "password")
@@ -36,12 +38,20 @@ class LoginSerializer(serializers.ModelSerializer):
             request=self.context["request"], email=data["email"], password=data["password"]
         )
         if not self.user:
-            raise ValidationError(_("Invalid username or password"))
+            raise ValidationError(self.bad_credentials_error)
 
         return data
 
     def save(self):
         return self.user
+
+
+class LoginUsingRegisterSerializer(LoginSerializer):
+    def validate(self, data):
+        if User.objects.filter(email=data["email"]).first() is None:
+            raise ValidationError(self.bad_credentials_error)
+
+        return super().validate(data)
 
 
 class UserSerializer(serializers.ModelSerializer):

--- a/backend/authentication/views.py
+++ b/backend/authentication/views.py
@@ -21,6 +21,7 @@ from .serializers import (
     RegistrationSerializer,
     LoginSerializer,
     UserSerializer,
+    LoginUsingRegisterSerializer,
 )
 from .models import User
 from .utils import (
@@ -72,7 +73,9 @@ def make_auth_view(*serializer_classes, action):
     return view
 
 
-register = make_auth_view(RegistrationSerializer, LoginSerializer, action="register")
+register = make_auth_view(
+    RegistrationSerializer, LoginUsingRegisterSerializer, action="register"
+)
 login = make_auth_view(LoginSerializer, action="login")
 
 


### PR DESCRIPTION
…ot exist

When the registration serializer fails validation, a login attempt is still made. This update will prevent the login attempt for accounts that do not exist. Lockouts will still happen when an email for an existing account is submitted (resulting in a real login attempt).

Other solutions to this could be to remove the login-using-register-form behavior, or to make sure that the field level validation is identical on the frontend and backend (which would prevent the registration serializer validation failures).